### PR TITLE
Uri bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ http.setup_edgegrid(
 )
 
 # example of simple GET request
-request = Net::HTTP::Get.new URI.join(baseuri.to_s, '/diagnostic-tools/v1/locations').to_s
+request_uri = URI.join(baseuri.to_s, '/diagnostic-tools/v1/locations')
+request = Net::HTTP::Get.new(request_uri)
 response = http.request(request)
 puts response.body
 

--- a/lib/akamai/edgegrid.rb
+++ b/lib/akamai/edgegrid.rb
@@ -119,12 +119,12 @@ module Akamai #:nodoc:
 
       # Returns a string with all data that will be signed
       def make_data_to_sign(request, auth_header)
-        url = URI(request.path)
+        
         data_to_sign = [
           request.method,
-          url.scheme,
+          request.uri.scheme,
           request.key?('host') ? request['host'] : url.host,
-          url.request_uri,
+          request.path,
           canonicalize_headers(request),
           make_content_hash(request),
           auth_header


### PR DESCRIPTION
The README usage suggests passing a String to ```Net::HTTP::Get.new```, when we really want to be using the URI we created with ```URI.join```.

The second bug is pretty obvious in that we cannot possibly get the correct scheme out of ```URI(request.path)```