### PR TITLE
Adding .edgerc authentication functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,36 @@ puts post_response.body
 3. Finally, use Net::HTTP methods as usual.  EdgegridHTTP will add 
    the property Authentication header to sign your http messages.
 
+Alternate Method using .edgerc
+------
+
+If you want to use the .edgerc method of authentication, similar to the
+python, php and Perl examples, you can find information on how to create
+the file on the developer portal in the Introduction section.  If you 
+are using the .edgerc file the example code is a little different:
+
+```
+require 'akamai/edgegrid'
+require 'net/http'
+require 'uri'
+
+http = Akamai::Edgegrid::HTTP.new(
+        section="default",
+        port=443
+)
+
+baseuri = URI('https://' + http.host)
+
+http.setup_edgegrid({})
+
+request = Net::HTTP::Get.new URI.join(baseuri.to_s, 'diagnostic-tools/v1/locations').to_s
+response = http.request(request)
+puts response.body
+
+```
+
+All other methods should work exactly the same.
+
 Author
 ------
 

--- a/akamai-edgegrid.gemspec
+++ b/akamai-edgegrid.gemspec
@@ -10,5 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/akamai-open/AkamaiOPEN-edgegrid-ruby"
   s.license     = 'Apache'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
+  s.add_runtime_dependency 'inifile', '~> 3.0'
   s.required_ruby_version = '>= 1.9'
 end

--- a/lib/akamai/edgegrid.rb
+++ b/lib/akamai/edgegrid.rb
@@ -7,7 +7,7 @@
 #
 # == License
 #
-#   Copyright 2014 Akamai Technologies, Inc. All rights reserved.
+#   Copyright 2014-2015 Akamai Technologies, Inc. All rights reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ require 'logger'
 require 'securerandom'
 require 'uri'
 require 'net/http'
+require 'inifile'
 
 module Akamai #:nodoc:
   module Edgegrid #:nodoc:
@@ -58,7 +59,7 @@ module Akamai #:nodoc:
     #   => "Hongkong, Hong Kong
     #
     class HTTP < Net::HTTP
-
+      attr_accessor :host, :section
       private
 
       def self.base64_hmac_sha256(data, key)
@@ -77,6 +78,21 @@ module Akamai #:nodoc:
 
       # Creates a new Akamai::Edgegrid::HTTP object (takes same options as Net::HTTP)
       def initialize(address, port)
+      	# If address isn't a URL, it's a section
+      	if !address.include? 'http' 
+      		edgerc_path = File.expand_path('~/.edgerc')
+      	
+      		if File.exist?(edgerc_path) 
+            @section = address
+            file = IniFile.load(edgerc_path)
+      			data = file[address]
+      			address = data["host"] || ""
+            address.gsub!('/','')
+            @host = address
+
+      		end
+      	end
+		
         super(address, port)
         if port == 80
           @use_ssl = false
@@ -164,6 +180,16 @@ module Akamai #:nodoc:
       # * +:max_body+ - Maximum POST body size accepted.  This info is provided by individual APIs (default 2048)
       # * +:debug+ - Enable extra logging (default 'false')
       def setup_edgegrid(opts)
+	        edgerc_path = File.expand_path('~/.edgerc')
+	
+        	if File.exist?(edgerc_path) && @section
+        		file = IniFile.load(edgerc_path)
+        		data = file[@section]
+        		opts[:client_token] ||= data["client_token"]
+        		opts[:client_secret] ||= data["client_secret"]
+        		opts[:access_token] ||= data["access_token"]
+        	end
+
         @client_token = opts[:client_token]
         @client_secret = opts[:client_secret]
         @access_token = opts[:access_token]

--- a/test/sample_edgerc
+++ b/test/sample_edgerc
@@ -1,0 +1,6 @@
+[default]
+client_secret = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
+host = akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/
+access_token = akab-access-token-xxx-xxxxxxxxxxxxxxxx
+client_token = akab-client-token-xxx-xxxxxxxxxxxxxxxx
+max-body = 131072

--- a/test/test_edgerc.rb
+++ b/test/test_edgerc.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+#
+# Original author: Jonathan Landis <jlandis@akamai.com>
+#
+# For more information visit https://developer.akamai.com
+#
+#   Copyright 2014 Akamai Technologies, Inc.  All rights reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter 'test'
+    command_name 'Mintest'
+  end
+end
+
+require 'minitest/unit'
+require 'minitest/autorun'
+require 'json'
+require 'uri'
+require_relative '../lib/akamai/edgegrid'
+
+class EdgegridTest < MiniTest::Unit::TestCase
+  @@testdata = JSON.parse(File.read("#{File.dirname(__FILE__)}/testdata.json"))
+
+  @@testdata['tests'].each do |testcase|
+    define_method("test_#{testcase['testName'].downcase.tr(" ", "_")}") do
+      baseuri = URI(@@testdata['base_url'])
+      http = Akamai::Edgegrid::HTTP.new(
+        address="",
+        port=443,
+	filename='test/sample_edgerc'
+      )
+
+      http.setup_from_edgerc(
+	:filename => 'test/sample_edgerc',
+        :headers_to_sign => @@testdata['headers_to_sign']
+      )
+
+      request_class = Net::HTTP.const_get(testcase['request']['method'].capitalize)
+      request = request_class.new URI.join(baseuri.to_s, testcase['request']['path']).to_s
+
+      if testcase['request']['headers']
+        testcase['request']['headers'].each do |header|
+          header.each do |k,v|
+            request.add_field(k,v)
+          end
+        end
+      end
+
+      if testcase['request']['data']
+        request.body = testcase['request']['data']
+      end
+
+      begin
+        auth_header = http.make_auth_header(
+          request,
+          @@testdata['timestamp'],
+          @@testdata['nonce']
+        )
+        assert_equal(testcase['expectedAuthorization'], auth_header)
+
+      rescue RuntimeError => err
+        assert_equal(testcase['failsWithMessage'], err.message)
+      end
+    end
+  end 
+
+  def test_nonce
+    count = 100
+    nonces = {}
+    while count > 0 do
+      n = Akamai::Edgegrid::HTTP.new_nonce()
+      refute_includes(nonces, n)
+      nonces[n] = 1
+      count -= 1
+    end
+  end
+
+  def test_timestamp
+    assert_match /^
+        \d{4}       # year
+        [0-1][0-9]  # month
+        [0-3][0-9]  # day
+        T
+        [0-2][0-9]  # hour
+        :
+        [0-5][0-9]  # minute
+        :
+        [0-5][0-9]  # second
+        [+]0000     # timezone
+    $/x, Akamai::Edgegrid::HTTP.eg_timestamp() 
+  end
+end


### PR DESCRIPTION
* Added accessors for host and section so users don't have to manually repeat them
* Added a function to read from the edgerc file when address doesn't have a scheme (section), and for the actual setting of client tokens and client secrets
* Updated the README to add a section on operating in this mode

* Rake test still runs clean,and I'm able to run my sample code (the readme stuff) successfully