### PR TITLE
Fixing with passing tests

### DIFF
--- a/test/sample_edgerc
+++ b/test/sample_edgerc
@@ -1,4 +1,4 @@
-[default]
+[test_edgerc]
 client_secret = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
 host = akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/
 access_token = akab-access-token-xxx-xxxxxxxxxxxxxxxx

--- a/test/test_edgerc.rb
+++ b/test/test_edgerc.rb
@@ -38,14 +38,16 @@ class EdgegridTest < MiniTest::Unit::TestCase
   @@testdata['tests'].each do |testcase|
     define_method("test_#{testcase['testName'].downcase.tr(" ", "_")}") do
       baseuri = URI(@@testdata['base_url'])
+      address = get_host("test/sample_edgerc","test_edgerc")
+
       http = Akamai::Edgegrid::HTTP.new(
-        address="",
-        port=443,
-	filename='test/sample_edgerc'
+        address=address,
+        443
       )
 
       http.setup_from_edgerc(
 	:filename => 'test/sample_edgerc',
+	:section  => 'test_edgerc',
         :headers_to_sign => @@testdata['headers_to_sign']
       )
 


### PR DESCRIPTION
I pulled the hostname stuff out of the initialize and moved it to a separate function.  Current tests pass, and the original functionality is basically restored.